### PR TITLE
Fix GTK version being loaded and new python

### DIFF
--- a/src/gloobus-preview-configuration
+++ b/src/gloobus-preview-configuration
@@ -6,7 +6,9 @@ import configparser
 import os
 import sys
 import glob
-from gi.repository import Gtk, GConf, Gio
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gio
 import signal
 import gettext
 #import config
@@ -163,7 +165,7 @@ class GUI:
 #==================================== GLOBAL FUNCTIONS ===============================================#		
 #=================== DEFAULT CONFIGURATION ================== #			
 def config_default():
-	config = configparser.SafeConfigParser()
+	config = configparser.ConfigParser()
 
 	config.add_section('Main')
 	config.add_section('Theme')


### PR DESCRIPTION
Fix python function using old library and specify GTK 3 to load.

I'm using Arch Linux and the settings didn't work I found the errors and fixed it with the newer version of libraries and specifying the gtk version to load.